### PR TITLE
feat: union-headword attestation signal (cut tier-A false positives)

### DIFF
--- a/.ai_state.md
+++ b/.ai_state.md
@@ -51,6 +51,16 @@
 - Historical `AllvsMW/PW/PWG/VCP` left as 2017 point-in-time runs (audit trail) — not overwritten.
 
 ## ✅ Completed (Recent only)
+- **Union-attestation signal (2026-06-26, branch `feat/union-attestation`):** wires the
+  PROJECT_INTERLINKS "union headword index → SpellCheck" feed. NEW `detectors/union_attestation.py`
+  loads SanskritLexicography's `HeadwordLists/union/union_headwords.tsv` (323k SLP1 headwords + n_dicts,
+  sibling repo, NOT committed here — env `SANSKRIT_UNION_HEADWORDS` / graceful absence like
+  get_external_source). `run_all.py` tags each candidate `union=N` and **demotes broadly-attested
+  suspects (≥5 dicts) A→B** (never below B, never for high-precision flaggers, never the whitelist).
+  **Honest finding:** at threshold 5 the tier-A FP reduction is small — tier-A suspects are almost all
+  union 0 (2167) or 1–2 (3005); only 197 at 3–4, **0 at ≥5** before demotion (just 2 demoted). The
+  per-candidate `union=N` tag is the more useful product; threshold is a maintainer tunable. Degrades
+  to no-op when the index is absent (verified: identical candidate counts).
 - **Hypothesis ledger + use cases** (changelog Unreleased): NEW `docs/HYPOTHESES.md` — 7 confirmed /
   4 refuted / 7 open hypotheses with evidence (body=ground-truth; tier-A precision split; do-not-file
   = deliverable; drift=f(reform type); metric dates the epoch; corpus-norm+freq=clean pairs; ext-src

--- a/detectors/run_all.py
+++ b/detectors/run_all.py
@@ -22,6 +22,7 @@ import subprocess
 import collections
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import slp1util as u
+import union_attestation as ua
 
 u.reconfigure_stdio()
 HERE = os.path.dirname(os.path.abspath(__file__))
@@ -58,7 +59,7 @@ CORROB_CW = 0.05
 
 class Cand:
     __slots__ = ('suspect', 'detectors', 'sugg_dets', 'sugg_dicts', 'reasons', 'dicts',
-                 'morph', 'corroborated')
+                 'morph', 'corroborated', 'union_n')
 
     def __init__(self, suspect):
         self.suspect = suspect
@@ -69,6 +70,7 @@ class Cand:
         self.dicts = set()
         self.morph = False                              # vidyut: suggestion is a valid stem, suspect is not
         self.corroborated = False                       # corpus+confusion corroboration (ranking nudge)
+        self.union_n = 0                                # union index: # of dicts attesting this suspect
 
 
 def ensure_outputs(sanhw1, rerun):
@@ -133,7 +135,7 @@ def aggregate():
     return cands
 
 
-def score_tier(c, dcs, weights, stems):
+def score_tier(c, dcs, weights, stems, union=None):
     ndet = len(c.detectors)
     # best suggestion = most detector support, then highest DCS band
     best, best_band, best_supp = '', 0, -1
@@ -151,8 +153,17 @@ def score_tier(c, dcs, weights, stems):
     # suggestion is a frequent DCS lemma, suspect is unattested, edit is a high-weight confusion.
     suspect_band = dcs.get(u.normalize_lemma(c.suspect), 0)
     c.corroborated = (best_band >= CORROB_SUGG_BAND and suspect_band == 0 and cw >= CORROB_CW)
+    # union attestation: the suspect itself is a headword in c.union_n dictionaries.
+    # Broad cross-dict attestation is strong evidence it is a real word, not a typo
+    # (the "attested in N other dicts -> not a typo" signal). It ranks a candidate
+    # DOWN within its tier and, when broadly attested, demotes tier A -> B -- but
+    # NEVER below B and NEVER for the high-precision flaggers (a charset/phonotactic
+    # violation is a real error even if a shared digitization mistake is attested
+    # in several dicts). When the union index is absent, c.union_n is 0 -> no effect.
+    c.union_n = ua.attestation(c.suspect, union) if union is not None else 0
     score = (ndet * 100 + best_band * 10 + (50 if hpf else 0) + len(c.dicts)
-             + round(cw * 20) + (15 if c.morph else 0) + (5 if c.corroborated else 0))
+             + round(cw * 20) + (15 if c.morph else 0) + (5 if c.corroborated else 0)
+             - min(c.union_n, 12))
     if c.detectors == {'dict_vs_corpus'}:
         tier = 'C'                              # exploratory alone (corroboration ranks it up in C)
     elif ndet >= 2 or hpf or best_band == 5:
@@ -161,6 +172,8 @@ def score_tier(c, dcs, weights, stems):
         tier = 'B'
     else:
         tier = 'C'
+    if tier == 'A' and not hpf and c.union_n >= ua.UNION_TRUST_DICTS:
+        tier = 'B'                              # broadly attested -> real word, demote out of tier A
     return score, tier, best, best_band
 
 
@@ -169,27 +182,38 @@ def main(sanhw1, rerun):
     dcs = u.load_dcs_lemmas(u.dcs_path())
     weights = u.load_confusion_weights()
     stems = u.load_vidyut_stems()
+    union = ua.load_union()
+    if union:
+        print("union attestation: %d headwords from %s" % (len(union), ua.union_path()))
+    else:
+        print("union attestation: index absent (%s) -- signal off" % ua.union_path())
     cands = aggregate()
 
     rows = []
     for c in cands.values():
-        score, tier, best, band = score_tier(c, dcs, weights, stems)
+        score, tier, best, band = score_tier(c, dcs, weights, stems, union)
         rows.append((score, tier, band, best, c))
     rows.sort(key=lambda r: (-r[0], r[4].suspect))
+    demoted = sum(1 for r in rows if r[4].union_n >= ua.UNION_TRUST_DICTS
+                  and not (r[4].detectors & HIGH_PRECISION))
 
     tiers = collections.Counter(r[1] for r in rows)
     multi = sum(1 for r in rows if len(r[4].detectors) >= 2)
     print("unified candidates: %d (deduped across %d detectors); multi-detector: %d"
           % (len(rows), len(DETECTORS), multi))
     print("tiers: A=%d  B=%d  C=%d" % (tiers['A'], tiers['B'], tiers['C']))
+    if union:
+        print("union-attested suspects (>=%d dicts, demoted A->B unless high-precision): %d"
+              % (ua.UNION_TRUST_DICTS, demoted))
 
     # combined_candidates.txt -- full ranked list
     with open(os.path.join(HERE, 'combined_candidates.txt'), 'w', encoding='utf-8') as f:
         for score, tier, band, best, c in rows:
             dets = ",".join(sorted(c.detectors))
-            f.write("%s\t%d\t%s -> %s\t[%s]\t[%s]%s\n"
+            f.write("%s\t%d\t%s -> %s\t[%s]\t[%s]%s%s\n"
                     % (tier, score, c.suspect, best or "(flag)", dets, ",".join(sorted(c.dicts)),
-                       "\tmorph" if c.morph else ""))
+                       "\tmorph" if c.morph else "",
+                       "\tunion=%d" % c.union_n if c.union_n else ""))
 
     # combined_sf.txt -- standard format; emit only the dicts a corrector tied to
     # the chosen suggestion (not flagger-contributed dicts with no correction evidence)

--- a/detectors/union_attestation.py
+++ b/detectors/union_attestation.py
@@ -1,0 +1,70 @@
+"""Union-headword attestation signal (PROJECT_INTERLINKS feed).
+
+Cross-dict attestation from SanskritLexicography's **union headword index**
+(`HeadwordLists/union/union_headwords.tsv`, ~323k SLP1 headwords each tagged with
+the number of dictionaries that attest it). A suspect that is itself attested
+across many *independent* Cologne dictionaries is very likely a real Sanskrit
+word, not a typo -- a ready-made "attested in N other dicts -> not a typo"
+signal that lets run_all.py demote broadly-attested suspects out of tier A,
+cutting the tier-A false-positive rate on mature dictionaries.
+
+The index lives in a SIBLING repo and is large + licensed, so it is NOT
+committed here. It is resolved like detectors/get_external_source.py: the env
+override `SANSKRIT_UNION_HEADWORDS`, else the default sibling path. If the file
+is absent, `load_union()` returns `{}` and every caller degrades to no-signal --
+the pipeline's behaviour is then unchanged.
+
+Keys are matched through slp1util.normalize_lemma (the same slp1_norm the union
+builder uses), so the two sides join cleanly. SLP1 throughout.
+"""
+import os
+
+import slp1util as u
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+# detectors/ -> repo root -> GitHub root -> SanskritLexicography sibling
+DEFAULT_UNION = os.path.normpath(os.path.join(
+    _HERE, "..", "..", "SanskritLexicography",
+    "HeadwordLists", "union", "union_headwords.tsv"))
+
+# Attested in >= this many dictionaries -> trust as a real word (conservative; the
+# union spans ~12 general Cologne dicts). A maintainer tunable.
+UNION_TRUST_DICTS = 5
+
+_cache = None
+
+
+def union_path():
+    return os.environ.get("SANSKRIT_UNION_HEADWORDS", DEFAULT_UNION)
+
+
+def load_union(path=None):
+    """Return {normalized SLP1 headword: n_dicts}. Empty {} if the index is absent."""
+    global _cache
+    if path is None and _cache is not None:
+        return _cache
+    resolved = path or union_path()
+    out = {}
+    if os.path.exists(resolved):
+        with open(resolved, "r", encoding="utf-8") as f:
+            f.readline()  # header: slp1 \t iast \t n_dicts \t dicts \t ...
+            for line in f:
+                parts = line.rstrip("\n").split("\t")
+                if len(parts) < 3:
+                    continue
+                try:
+                    n = int(parts[2])
+                except ValueError:
+                    continue
+                key = u.normalize_lemma(parts[0])
+                if n > out.get(key, 0):
+                    out[key] = n
+    if path is None:
+        _cache = out
+    return out
+
+
+def attestation(slp1, union=None):
+    """Number of dictionaries attesting this SLP1 headword (0 if unknown/absent)."""
+    idx = union if union is not None else load_union()
+    return idx.get(u.normalize_lemma(slp1), 0)


### PR DESCRIPTION
## What

Wires the **union headword index → SanskritSpellCheck** feed from `PROJECT_INTERLINKS.md`. A suspect that is itself a headword in many *independent* Cologne dictionaries is very likely a real Sanskrit word, not a typo — the "attested in N other dicts → not a typo" signal.

## How

- New `detectors/union_attestation.py` loads SanskritLexicography's `HeadwordLists/union/union_headwords.tsv` (~323k SLP1 headwords each tagged with `n_dicts`). Keys are matched through `slp1util.normalize_lemma` (the same `slp1_norm` the union builder uses).
- The index is large + licensed and lives in a **sibling repo**, so it is **not committed here** — resolved via `SANSKRIT_UNION_HEADWORDS` or the default sibling path, exactly like `get_external_source.py`. **When absent the signal is a no-op** (verified: identical candidate counts).
- `run_all.py` tags each candidate `union=N` and **demotes broadly-attested suspects (≥ `UNION_TRUST_DICTS` = 5) from tier A → B**. Conservative by construction: never below B, never for the high-precision flaggers (`charset`/`phonotactic` — a shared digitization error is still an error), never overriding the `nochange` whitelist. Also a within-tier rank nudge.

## Honest measured impact

On the current `sanhw1.txt` (cached detector outputs), tier-A suspects by union attestation:

| union n_dicts | 0 | 1–2 | 3–4 | ≥5 |
|---|--:|--:|--:|--:|
| tier-A suspects | 2167 | 3005 | 197 | 0* |

\*the ≥5 cases were demoted (only 2). **Tier-A false positives are almost all attested in 0–2 dicts** — the genuine-typo-likely cases that by nature *aren't* broadly attested — so cross-dict attestation barely reaches tier A at a safe threshold. The more immediately useful product is the per-candidate **`union=N` tag** for reviewer triage; `UNION_TRUST_DICTS` is left as a maintainer tunable (lowering to 3 would reach the 197 borderline cases, at some risk to shared-OCR errors).

## Safety

Read-only consumption of a sibling asset; touches no `corrections_draft/`, `nochange/`, or other human-reviewed data; gitignored `combined_*` outputs only. No-op when the index is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)